### PR TITLE
Update: Added DSA Links to root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Topics we will be covering:
 2. [**React**](./React/) : Commonly asked questions and core concepts.
 3. [**CSS**](./CSS/) : Commonly asked questions and a few concepts.
 4. [**Web Fundamentals**](./Web%20Fundamentals/) : A lot of important topics.
+5. [**DSA**](./DSA/) : Code for data structures and miscellaneous concepts.
 
 ## About
 
@@ -26,11 +27,12 @@ I am looking for a couple of folks to help me maintain this repo. Feel free to r
 There are 5 different folders in this repo:
 
 1. [**CSS**](./CSS/)
-2. **DSA**
-3. [**JavaScript**](./JavaScript/)
-4. [**React**](./React/)
-5. [**Web Fundamentals**](./Web%20Fundamentals/)
-   Each folder contains information about the content.
+2. [**JavaScript**](./JavaScript/)
+3. [**React**](./React/)
+4. [**Web Fundamentals**](./Web%20Fundamentals/)
+5. [**DSA**](./DSA/)
+
+Each folder contains information about the content.
 
 # Found some issue in the repo?
 
@@ -97,7 +99,7 @@ Now, you're ready to start contributing!
 
 ### Folder Structure
 
-This repository is organized into folders for different topics like JavaScript, React, CSS, and Web Fundamentals. Please make sure to place your contributions in the appropriate folder. If a folder doesn't exist for your specific topic, you can create it.
+This repository is organized into folders for different topics like JavaScript, React, CSS, Web Fundamentals, and DSA. Please make sure to place your contributions in the appropriate folder. If a folder doesn't exist for your specific topic, you can create it.
 
 ```
 - JavaScript/
@@ -120,6 +122,7 @@ This repository is organized into folders for different topics like JavaScript, 
   - README.md
 - Web Fundamentals/
   - README.md
+- DSA/
 ```
 
 ### Adding Content


### PR DESCRIPTION
This PR aims to fix #20 . I've added relevant links for **DSA** to the root `README.md`.
Possible improvements:
- README.md can be added to `DSA/` in `### Folder Structure`, but only after it has already been added in the folder.