### PR TITLE
Correct typo error from innerHTM to innerHTML

### DIFF
--- a/JavaScript/JavaScript Basics/README.md
+++ b/JavaScript/JavaScript Basics/README.md
@@ -401,7 +401,7 @@ document.querySelector("body").appendChild(div);
 
 //After
 const myDiv = `<div><p>My name is ${name}</p></div>`;
-document.querySelector("body").innerHTM = myDiv;
+document.querySelector("body").innerHTML = myDiv;
 ```
 
 ## IIFE


### PR DESCRIPTION
To append `myDiv` to the body, we should use `innerHTML` instead of `innerHTM`. I think this is a typo error.